### PR TITLE
Change fatal log to error return

### DIFF
--- a/ip2cidr.go
+++ b/ip2cidr.go
@@ -1,91 +1,90 @@
 package ip2cidr
 
 import (
-   "encoding/binary"
-   "errors"
-   "fmt"
-   "log"
-   "math"
-   "net"
-   "strconv"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"strconv"
 )
 
 func IPRangeToCIDR(start, end string) ([]string, error) {
-   cidrToMask := []uint32{
-      0x00000000, 0x80000000, 0xC0000000,
-      0xE0000000, 0xF0000000, 0xF8000000,
-      0xFC000000, 0xFE000000, 0xFF000000,
-      0xFF800000, 0xFFC00000, 0xFFE00000,
-      0xFFF00000, 0xFFF80000, 0xFFFC0000,
-      0xFFFE0000, 0xFFFF0000, 0xFFFF8000,
-      0xFFFFC000, 0xFFFFE000, 0xFFFFF000,
-      0xFFFFF800, 0xFFFFFC00, 0xFFFFFE00,
-      0xFFFFFF00, 0xFFFFFF80, 0xFFFFFFC0,
-      0xFFFFFFE0, 0xFFFFFFF0, 0xFFFFFFF8,
-      0xFFFFFFFC, 0xFFFFFFFE, 0xFFFFFFFF,
-   }
+	cidrToMask := []uint32{
+		0x00000000, 0x80000000, 0xC0000000,
+		0xE0000000, 0xF0000000, 0xF8000000,
+		0xFC000000, 0xFE000000, 0xFF000000,
+		0xFF800000, 0xFFC00000, 0xFFE00000,
+		0xFFF00000, 0xFFF80000, 0xFFFC0000,
+		0xFFFE0000, 0xFFFF0000, 0xFFFF8000,
+		0xFFFFC000, 0xFFFFE000, 0xFFFFF000,
+		0xFFFFF800, 0xFFFFFC00, 0xFFFFFE00,
+		0xFFFFFF00, 0xFFFFFF80, 0xFFFFFFC0,
+		0xFFFFFFE0, 0xFFFFFFF0, 0xFFFFFFF8,
+		0xFFFFFFFC, 0xFFFFFFFE, 0xFFFFFFFF,
+	}
 
-   startAddr, err := ipToLong(start)
-   if err != nil {
-      return []string{}, err
-   }
-   endAddr, err := ipToLong(end)
-   if err != nil {
-      return []string{}, err
-   }
+	startAddr, err := ipToLong(start)
+	if err != nil {
+		return []string{}, err
+	}
+	endAddr, err := ipToLong(end)
+	if err != nil {
+		return []string{}, err
+	}
 
-   if startAddr > endAddr {
-      return []string{}, errors.New("start of IP range must be less than the end")
-   }
+	if startAddr > endAddr {
+		return []string{}, errors.New("start of IP range must be less than the end")
+	}
 
-   var cidrList []string
+	var cidrList []string
 
-   for i := endAddr; i >= startAddr; i-- {
-      maxSize := 32
-      for j := maxSize; j > 0; j-- {
-          mask := cidrToMask[maxSize - 1]
-          maskedBase := startAddr & mask
+	for i := endAddr; i >= startAddr; i-- {
+		maxSize := 32
+		for j := maxSize; j > 0; j-- {
+			mask := cidrToMask[maxSize-1]
+			maskedBase := startAddr & mask
 
-          if maskedBase != startAddr {
-              break
-          }
+			if maskedBase != startAddr {
+				break
+			}
 
-          maxSize--
-      }
+			maxSize--
+		}
 
-      x := math.Log(float64(endAddr - startAddr + 1)) / math.Log(2)
-      maxDiff := int(32) - int(math.Floor(x))
-      if maxSize < maxDiff {
-         maxSize = maxDiff
-      }
+		x := math.Log(float64(endAddr-startAddr+1)) / math.Log(2)
+		maxDiff := int(32) - int(math.Floor(x))
+		if maxSize < maxDiff {
+			maxSize = maxDiff
+		}
 
-      cidrList = append(cidrList, fmt.Sprintf("%s/%s", longToIP(startAddr), strconv.Itoa(maxSize)))
-      startAddr += uint32(math.Pow(2, float64(32 - maxSize)))
-   }
-   return cidrList, nil
+		cidrList = append(cidrList, fmt.Sprintf("%s/%s", longToIP(startAddr), strconv.Itoa(maxSize)))
+		startAddr += uint32(math.Pow(2, float64(32-maxSize)))
+	}
+	return cidrList, nil
 }
 
 func ipToLong(ips string) (uint32, error) {
-   ip := net.ParseIP(ips)
-   if ip == nil {
-      return 0, errors.New("wrong IP address format")
-   }
-   ip = ip.To4()
-   return binary.BigEndian.Uint32(ip), nil
+	ip := net.ParseIP(ips)
+	if ip == nil {
+		return 0, errors.New("wrong IP address format")
+	}
+	ip = ip.To4()
+	return binary.BigEndian.Uint32(ip), nil
 }
 
 func longToIP(ipl uint32) string {
-   ipb := make([]byte, 4)
-   binary.BigEndian.PutUint32(ipb, ipl)
-   ip := net.IP(ipb)
-   return ip.String()
+	ipb := make([]byte, 4)
+	binary.BigEndian.PutUint32(ipb, ipl)
+	ip := net.IP(ipb)
+	return ip.String()
 }
 
 func intToIP(ipi uint32) string {
-   result := make(net.IP, 4)
-   result[0] = byte(ipi)
-   result[1] = byte(ipi >> 8)
-   result[2] = byte(ipi >> 16)
-   result[3] = byte(ipi >> 24)
-   return result.String()
+	result := make(net.IP, 4)
+	result[0] = byte(ipi)
+	result[1] = byte(ipi >> 8)
+	result[2] = byte(ipi >> 16)
+	result[3] = byte(ipi >> 24)
+	return result.String()
 }

--- a/ip2cidr.go
+++ b/ip2cidr.go
@@ -27,11 +27,11 @@ func IPRangeToCIDR(start, end string) ([]string, error) {
 
    startAddr, err := ipToLong(start)
    if err != nil {
-      log.Fatalf(err.Error())
+      return []string{}, err
    }
    endAddr, err := ipToLong(end)
    if err != nil {
-      log.Fatalf(err.Error())
+      return []string{}, err
    }
 
    if startAddr > endAddr {

--- a/ip2cidr_test.go
+++ b/ip2cidr_test.go
@@ -1,26 +1,42 @@
 package ip2cidr
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 )
 
 func TestConvert(t *testing.T) {
-    tests := []struct {
-        startIP string
-        endIP string
-        want []string
-    }{
-        {startIP: "1.0.64.0", endIP: "1.0.127.255", want: []string{"1.0.64.0/18"}},
-        {startIP: "1.0.140.0", endIP: "1.0.175.255", want: []string{"1.0.140.0/22", "1.0.144.0/20", "1.0.160.0/20"}},
-    }
-    for _, tt := range tests {
-        got, err := IPRangeToCIDR(tt.startIP, tt.endIP)
-        if err != nil {
-            t.Fatal(err)
-        }
-        if strings.Compare(got[0], tt.want[0]) != 0 {
-            t.Errorf("%v-%v = %v; want %v", tt.startIP, tt.endIP, got, tt.want)
-        }
-    }
+	tests := []struct {
+		startIP string
+		endIP   string
+		want    []string
+	}{
+		{startIP: "1.0.64.0", endIP: "1.0.127.255", want: []string{"1.0.64.0/18"}},
+		{startIP: "1.0.140.0", endIP: "1.0.175.255", want: []string{"1.0.140.0/22", "1.0.144.0/20", "1.0.160.0/20"}},
+	}
+	for _, tt := range tests {
+		got, err := IPRangeToCIDR(tt.startIP, tt.endIP)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Compare(got[0], tt.want[0]) != 0 {
+			t.Errorf("%v-%v = %v; want %v", tt.startIP, tt.endIP, got, tt.want)
+		}
+	}
+}
+
+func TestConvertFailure(t *testing.T) {
+	tests := []struct {
+		startIP string
+		endIP   string
+	}{
+		{startIP: "1.0.64.0", endIP: "1.0.127.256"},
+		{startIP: "1.0.260.0", endIP: "1.0.175.255"},
+	}
+	for _, tt := range tests {
+		_, err := IPRangeToCIDR(tt.startIP, tt.endIP)
+		if err == nil {
+			t.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
Hi! On this PR i would like to propose a change to the current code.

When an invalid input is given to parse, instead of logging a fatal error, return the error with an empty slice.

Comments are more than welcome!